### PR TITLE
refactor: move message handling script to head and update style loadi…

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,34 +1,42 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <script>
+      window.addEventListener("message", (event) => {
+        // Asegúrate de validar el origen para evitar recibir mensajes de orígenes no deseados
+        if (event.origin !== "http://localhost:4200") {
+          return; // Puedes reemplazar esta URL con el dominio real de tu aplicación
+        }
+
+        // Obtener los datos del mensaje
+        const data = event.data;
+
+        // Verificar que el tipo de mensaje es el esperado
+        if (data.type === "loadStyles") {
+          // Crear el elemento <link> para cargar los estilos
+          const link = document.createElement("link");
+          link.rel = "stylesheet";
+          link.href = data.url; // URL recibida en el mensaje
+          document.head.appendChild(link); // Agregar el link a la cabeza del iframe
+        }
+      });
+    </script>
     <meta charset="utf-8" />
     <title>InterviewProject</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
+    <!-- <link
+      rel="stylesheet"
+      href="https://daniel-guerrero-portafolio.netlify.app/assets/design-system/accela-theme.css"
+    /> -->
   </head>
-  <body class="mat-typography">
+  <body class="accela-theme">
     <app-root></app-root>
   </body>
-  <script>
-    window.addEventListener("message", (event) => {
-      // Asegúrate de validar el origen para evitar recibir mensajes de orígenes no deseados
-      if (event.origin !== "http://localhost:4200") {
-        return; // Puedes reemplazar esta URL con el dominio real de tu aplicación
-      }
-
-      // Obtener los datos del mensaje
-      const data = event.data;
-
-      // Verificar que el tipo de mensaje es el esperado
-      if (data.type === "loadStyles") {
-        // Crear el elemento <link> para cargar los estilos
-        const link = document.createElement("link");
-        link.rel = "stylesheet";
-        link.href = data.url; // URL recibida en el mensaje
-        document.head.appendChild(link); // Agregar el link a la cabeza del iframe
-      }
-    });
-  </script>
 </html>


### PR DESCRIPTION
This pull request includes changes to the `src/index.html` file to update the HTML structure and include new styles and fonts. The most important changes are:

HTML structure updates:

* Moved the `<meta charset="utf-8" />`, `<title>InterviewProject</title>`, `<base href="/" />`, `<meta name="viewport" content="width=device-width, initial-scale=1" />`, `<link rel="icon" type="image/x-icon" href="favicon.ico" />`, and `<link rel="preconnect" href="https://fonts.gstatic.com" />` tags to a new location within the `<head>` section. [[1]](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL4-L13) [[2]](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeR24-R41)

Style and font updates:

* Added a new `<link>` tag to include Material Icons from Google Fonts.
* Updated the class attribute of the `<body>` tag to use `accela-theme` instead of `mat-typography`.
* Commented out a `<link>` tag that was previously used to include a stylesheet from an external URL